### PR TITLE
Fix prime check for small numbers in adboxes

### DIFF
--- a/adboxes.c
+++ b/adboxes.c
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 
 static inline const unsigned is_prime(const unsigned n) {
+  if (n == 2 || n == 3)
+    return 1;
   if (n % 2 == 0 || n % 3 == 0)
     return 0;
   for (unsigned i = 5; i * i <= n; i += 6)


### PR DESCRIPTION
## Summary
- correct the `is_prime` helper to recognize 2 and 3 as prime
- recompile `adboxes.c` to confirm the program builds with the updated check

## Testing
- `clang -o a adboxes.c`

------
https://chatgpt.com/codex/tasks/task_e_68409d2d39e883289d8665f9216ff04c