### PR TITLE
Graceful failure when Magoo DB is full

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ clang -o bran bran.c
 
 ## Experiment: Magoo DB
 
-`magoo_db.c` is the simplest possible in memory CRUD database. Compile with
+`magoo_db.c` is the simplest possible in memory CRUD database. Record IDs start at `1` and `0` indicates a failure to create a record. Compile with
 ```sh
 clang -o magoo magoo_db.c
 ```


### PR DESCRIPTION
## Summary
- document valid ID range
- prevent `create_record` overflow by checking `next_id`
- use 16-bit `next_id` and fix initialization loop
- exit early in `main` if a record creation fails

## Testing
- `clang -o magoo magoo_db.c`
- `./magoo`
- `clang -o bran bran.c`
- `clang -o adboxes adboxes.c`
- `clang -o runs runs.c`
- `clang -O3 -march=native -fopenmp -funroll-loops -ffast-math -flto -fuse-ld=gold prime_finite_differences.c -o p -lm` *(fails: 'omp.h' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409d2dcb5883289696bfc920e8f112