### PR TITLE
Add Makefile to compile experiments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+CC?=clang
+CFLAGS_PFD=-O3 -march=native -fopenmp -funroll-loops -ffast-math -flto -fuse-ld=gold
+
+.PHONY: adboxes bran magoo pfd runs all
+
+adboxes: adboxes.c
+	$(CC) -o a adboxes.c
+
+bran: bran.c
+	$(CC) -o bran bran.c
+
+magoo: magoo_db.c
+	$(CC) -o magoo magoo_db.c
+
+pfd: prime_finite_differences.c
+	$(CC) $(CFLAGS_PFD) prime_finite_differences.c -o p -lm
+
+runs: runs.c
+	$(CC) -o r runs.c
+
+all: adboxes bran magoo pfd runs

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Various mathematical experiments.
 
+## Building with Makefile
+
+Run `make adboxes`, `make bran`, `make magoo`, `make pfd` or `make runs` to
+compile individual experiments. `make all` builds every program.
+
 ## Experiment: Arithmetic Derivatives
 
 `adboxes.c` visualizes the modular spread of the arithmetic derivative. Compile with


### PR DESCRIPTION
## Summary
- add Makefile with individual build targets and an `all` target
- document the Makefile usage in `README`

## Testing
- `make CC=/usr/bin/clang all`

------
https://chatgpt.com/codex/tasks/task_e_68409d2f487083288b5de825cf411d0a